### PR TITLE
Add mutually assured destruction turn type features and refactor setup method

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -45,9 +45,9 @@ class Turn
         @spoils_of_war << @player1.deck.cards.shift
         @spoils_of_war << @player2.deck.cards.shift
       end
-    # elsif self.type == :mutually_assured_destruction
-    #   @player1.deck.cards.shift(3)
-    #   @player2.deck.cards.shift(3)
+    elsif self.type == :mutually_assured_destruction
+      @player1.deck.cards.shift(3)
+      @player2.deck.cards.shift(3)
     end
   end
 

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -16,6 +16,7 @@ class Turn
       :war
     end
   end
+  # turn this into an attribute w an attr_reader eventually?
 
   def winner
     if self.type == :basic
@@ -30,8 +31,8 @@ class Turn
       elsif @player2.deck.rank_of_card_at(2) > @player1.deck.rank_of_card_at(2)
         player2
       end
-    # elsif self.type == :mutually_assured_destruction
-    #   "No winner"
+    elsif self.type == :mutually_assured_destruction
+      "No Winner"
     end
   end
 

--- a/test/turn_test.rb
+++ b/test/turn_test.rb
@@ -35,7 +35,7 @@ class TurnTest < Minitest::Test
   end
 
   def test_it_starts_with_no_spoils_of_war
-    assert_equal [], @turn.spoils_of_war
+    assert_empty @turn.spoils_of_war
   end
 
   def test_it_can_identify_turn_type_when_basic
@@ -130,7 +130,7 @@ class TurnTest < Minitest::Test
 
     @turn.pile_cards
 
-    assert_equal [], @turn.spoils_of_war
+    assert_empty @turn.spoils_of_war
 
     assert_equal [@card8], @turn.player1.deck.cards
     assert_equal [@card7], @turn.player2.deck.cards
@@ -144,7 +144,7 @@ class TurnTest < Minitest::Test
     assert_equal [@card2, @card5, @card8, @card1, @card3], @player1.deck.cards
     assert_equal [@card4, @card6, @card7], @player2.deck.cards
 
-    assert_equal [], @turn.spoils_of_war
+    assert_empty @turn.spoils_of_war
   end
 end
 
@@ -160,11 +160,8 @@ def test_it_awards_spoils_of_war_to_winner_of_turn_when_type_is_war
   @turn.pile_cards
   @turn.award_spoil(winner)
 
-  assert_equal [], @player1.deck.cards
-  assert_equal [], @player2.deck.cards
+  assert_empty @player1.deck.cards
+  assert_empty @player2.deck.cards
 
-  assert_equal [], @turn.spoils_of_war
+  assert_empty @turn.spoils_of_war
 end
-
-
-#try assert_empty for @spoils_of_war

--- a/test/turn_test.rb
+++ b/test/turn_test.rb
@@ -42,7 +42,6 @@ class TurnTest < Minitest::Test
     assert_equal :basic, @turn.type
   end
 
-  # add tests identifying other turn types
   def test_it_can_identify_turn_type_when_war
     @deck1 = Deck.new([@card1, @card2, @card5, @card8])
     @deck2 = Deck.new([@card4, @card3, @card6, @card7])
@@ -84,6 +83,19 @@ class TurnTest < Minitest::Test
     assert_equal @player2, @turn.winner
   end
 
+  def test_there_is_no_turn_winner_when_mutually_assured_destruction
+    @card6 = Card.new(:diamond, '8', 8)
+
+    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
+    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
+
+    @player1 = Player.new("Megan", @deck1)
+    @player2 = Player.new("Aurora", @deck2)
+
+    @turn = Turn.new(@player1, @player2)
+
+    assert_equal "No Winner", @turn.winner
+  end
 
   def test_pile_cards_method_sends_top_card_from_each_players_deck_to_spoils_of_war_when_turn_type_is_basic
     @turn.pile_cards

--- a/test/turn_test.rb
+++ b/test/turn_test.rb
@@ -16,152 +16,111 @@ class TurnTest < Minitest::Test
     @card7 = Card.new(:heart, '3', 3)
     @card8 = Card.new(:diamond, '2', 2)
 
-    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
-    @deck2 = Deck.new([@card3, @card4, @card6, @card7])
+    @basic_turn_deck1 = Deck.new([@card1, @card2, @card5, @card8])
+    @basic_turn_deck2 = Deck.new([@card3, @card4, @card6, @card7])
 
-    @player1 = Player.new("Megan", @deck1)
-    @player2 = Player.new("Aurora", @deck2)
+    @basic_turn_player1 = Player.new("Megan", @basic_turn_deck1)
+    @basic_turn_player2 = Player.new("Aurora", @basic_turn_deck2)
 
-    @turn = Turn.new(@player1, @player2)
+    @basic_turn = Turn.new(@basic_turn_player1, @basic_turn_player2)
+
+    @war_turn_deck1 = Deck.new([@card1, @card2, @card5, @card8])
+    @war_turn_deck2 = Deck.new([@card4, @card3, @card6, @card7])
+    @war_turn_player1 = Player.new("Megan", @war_turn_deck1)
+    @war_turn_player2 = Player.new("Aurora", @war_turn_deck2)
+
+    @war_turn = Turn.new(@war_turn_player1, @war_turn_player2)
+
+    @mad_card6 = Card.new(:diamond, '8', 8)
+
+    @mad_turn_deck1 = Deck.new([@card1, @card2, @card5, @card8])
+    @mad_turn_deck2 = Deck.new([@card4, @card3, @mad_card6, @card7])
+
+    @mad_turn_player1 = Player.new("Megan", @mad_turn_deck1)
+    @mad_turn_player2 = Player.new("Aurora", @mad_turn_deck2)
+
+    @mad_turn = Turn.new(@mad_turn_player1, @mad_turn_player2)
   end
 
   def test_it_exists
-    assert_instance_of Turn, @turn
+    assert_instance_of Turn, @basic_turn
   end
 
   def test_it_has_two_players
-    assert_equal @player1, @turn.player1
-    assert_equal @player2, @turn.player2
+    assert_equal @basic_turn_player1, @basic_turn.player1
+    assert_equal @basic_turn_player2, @basic_turn.player2
   end
 
   def test_it_starts_with_no_spoils_of_war
-    assert_empty @turn.spoils_of_war
+    assert_empty @basic_turn.spoils_of_war
   end
 
   def test_it_can_identify_turn_type_when_basic
-    assert_equal :basic, @turn.type
+    assert_equal :basic, @basic_turn.type
   end
 
   def test_it_can_identify_turn_type_when_war
-    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
-    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
-    @player1 = Player.new("Megan", @deck1)
-    @player2 = Player.new("Aurora", @deck2)
-
-    @turn = Turn.new(@player1, @player2)
-
-    assert_equal :war, @turn.type
+    assert_equal :war, @war_turn.type
   end
 
   def test_it_can_identify_turn_type_when_mutually_assured_destruction
-    @card6 = Card.new(:diamond, '8', 8)
-
-    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
-    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
-
-    @player1 = Player.new("Megan", @deck1)
-    @player2 = Player.new("Aurora", @deck2)
-
-    @turn = Turn.new(@player1, @player2)
-
-    assert_equal :mutually_assured_destruction, @turn.type
+    assert_equal :mutually_assured_destruction, @mad_turn.type
   end
 
   def test_it_can_identify_a_turn_winner_when_basic
-    assert_equal @player1, @turn.winner
+    assert_equal @basic_turn_player1, @basic_turn.winner
   end
 
-  # add tests identifying winners with other turn types
   def test_it_can_identify_a_turn_winner_when_war
-    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
-    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
-    @player1 = Player.new("Megan", @deck1)
-    @player2 = Player.new("Aurora", @deck2)
-
-    @turn = Turn.new(@player1, @player2)
-
-    assert_equal @player2, @turn.winner
+    assert_equal @war_turn_player2, @war_turn.winner
   end
 
   def test_there_is_no_turn_winner_when_mutually_assured_destruction
-    @card6 = Card.new(:diamond, '8', 8)
-
-    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
-    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
-
-    @player1 = Player.new("Megan", @deck1)
-    @player2 = Player.new("Aurora", @deck2)
-
-    @turn = Turn.new(@player1, @player2)
-
-    assert_equal "No Winner", @turn.winner
+    assert_equal "No Winner", @mad_turn.winner
   end
 
   def test_pile_cards_method_sends_top_card_from_each_players_deck_to_spoils_of_war_when_turn_type_is_basic
-    @turn.pile_cards
-    assert_equal [@card1, @card3], @turn.spoils_of_war
-    assert_equal [@card2, @card5, @card8], @player1.deck.cards
-    assert_equal [@card4, @card6, @card7], @player2.deck.cards
+    @basic_turn.pile_cards
+    assert_equal [@card1, @card3], @basic_turn.spoils_of_war
+    assert_equal [@card2, @card5, @card8], @basic_turn_player1.deck.cards
+    assert_equal [@card4, @card6, @card7], @basic_turn_player2.deck.cards
   end
 
   def test_pile_cards_method_sends_top_three_cards_from_each_players_deck_to_spoils_of_war_when_turn_type_is_war
-    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
-    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
-    @player1 = Player.new("Megan", @deck1)
-    @player2 = Player.new("Aurora", @deck2)
-
-    @turn = Turn.new(@player1, @player2)
-
-    @turn.pile_cards
-    assert_equal [@card1, @card4, @card2, @card3, @card5, @card6], @turn.spoils_of_war
+    @war_turn.pile_cards
+    assert_equal [@card1, @card4, @card2, @card3, @card5, @card6], @war_turn.spoils_of_war
   end
 
 # simplify this name!!!
   def test_pile_cards_method_removes_top_three_cards_from_each_players_deck_without_adding_them_to_spoils_of_war_when_turn_type_is_mutually_assured_destruction
-    @card6 = Card.new(:diamond, '8', 8)
+    @mad_turn.pile_cards
 
-    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
-    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
+    assert_empty @mad_turn.spoils_of_war
 
-    @player1 = Player.new("Megan", @deck1)
-    @player2 = Player.new("Aurora", @deck2)
-
-    @turn = Turn.new(@player1, @player2)
-
-    @turn.pile_cards
-
-    assert_empty @turn.spoils_of_war
-
-    assert_equal [@card8], @turn.player1.deck.cards
-    assert_equal [@card7], @turn.player2.deck.cards
+    assert_equal [@card8], @mad_turn.player1.deck.cards
+    assert_equal [@card7], @mad_turn.player2.deck.cards
   end
 
   def test_it_awards_spoils_of_war_to_winner_of_turn_when_type_is_basic
-    winner = @turn.winner
-    @turn.pile_cards
-    @turn.award_spoils(winner)
+    winner = @basic_turn.winner
+    @basic_turn.pile_cards
+    @basic_turn.award_spoils(winner)
 
-    assert_equal [@card2, @card5, @card8, @card1, @card3], @player1.deck.cards
-    assert_equal [@card4, @card6, @card7], @player2.deck.cards
+    assert_equal [@card2, @card5, @card8, @card1, @card3], @basic_turn_player1.deck.cards
+    assert_equal [@card4, @card6, @card7], @basic_turn_player2.deck.cards
 
-    assert_empty @turn.spoils_of_war
+    assert_empty @basic_turn.spoils_of_war
   end
-end
 
-def test_it_awards_spoils_of_war_to_winner_of_turn_when_type_is_war
-  @deck1 = Deck.new([@card1, @card2, @card5, @card8])
-  @deck2 = Deck.new([@card4, @card3, @card6, @card7])
-  @player1 = Player.new("Megan", @deck1)
-  @player2 = Player.new("Aurora", @deck2)
+  def test_it_awards_spoils_of_war_to_winner_of_turn_when_type_is_war
+    winner = @war_turn.winner
 
-  @turn = Turn.new(@player1, @player2)
+    @war_turn.pile_cards
+    @war_turn.award_spoils(winner)
 
-  winner = turn.winner
-  @turn.pile_cards
-  @turn.award_spoil(winner)
+    assert_equal [@card8], @war_turn_player1.deck.cards
+    assert_equal [@card7, @card1, @card4, @card2, @card3, @card5, @card6], @war_turn_player2.deck.cards
 
-  assert_empty @player1.deck.cards
-  assert_empty @player2.deck.cards
-
-  assert_empty @turn.spoils_of_war
+    assert_empty @war_turn.spoils_of_war
+  end
 end

--- a/test/turn_test.rb
+++ b/test/turn_test.rb
@@ -104,7 +104,6 @@ class TurnTest < Minitest::Test
     assert_equal [@card4, @card6, @card7], @player2.deck.cards
   end
 
-  # add tests pile_cards for other turn types
   def test_pile_cards_method_sends_top_three_cards_from_each_players_deck_to_spoils_of_war_when_turn_type_is_war
     @deck1 = Deck.new([@card1, @card2, @card5, @card8])
     @deck2 = Deck.new([@card4, @card3, @card6, @card7])
@@ -115,6 +114,26 @@ class TurnTest < Minitest::Test
 
     @turn.pile_cards
     assert_equal [@card1, @card4, @card2, @card3, @card5, @card6], @turn.spoils_of_war
+  end
+
+# simplify this name!!!
+  def test_pile_cards_method_removes_top_three_cards_from_each_players_deck_without_adding_them_to_spoils_of_war_when_turn_type_is_mutually_assured_destruction
+    @card6 = Card.new(:diamond, '8', 8)
+
+    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
+    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
+
+    @player1 = Player.new("Megan", @deck1)
+    @player2 = Player.new("Aurora", @deck2)
+
+    @turn = Turn.new(@player1, @player2)
+
+    @turn.pile_cards
+
+    assert_equal [], @turn.spoils_of_war
+
+    assert_equal [@card8], @turn.player1.deck.cards
+    assert_equal [@card7], @turn.player2.deck.cards
   end
 
   def test_it_awards_spoils_of_war_to_winner_of_turn_when_type_is_basic
@@ -128,7 +147,6 @@ class TurnTest < Minitest::Test
     assert_equal [], @turn.spoils_of_war
   end
 end
-#try assert_empty for @spoils_of_war
 
 def test_it_awards_spoils_of_war_to_winner_of_turn_when_type_is_war
   @deck1 = Deck.new([@card1, @card2, @card5, @card8])
@@ -147,3 +165,6 @@ def test_it_awards_spoils_of_war_to_winner_of_turn_when_type_is_war
 
   assert_equal [], @turn.spoils_of_war
 end
+
+
+#try assert_empty for @spoils_of_war

--- a/test/turn_test.rb
+++ b/test/turn_test.rb
@@ -54,6 +54,19 @@ class TurnTest < Minitest::Test
     assert_equal :war, @turn.type
   end
 
+  def test_it_can_identify_turn_type_when_mutually_assured_destruction
+    @card6 = Card.new(:diamond, '8', 8)
+
+    @deck1 = Deck.new([@card1, @card2, @card5, @card8])
+    @deck2 = Deck.new([@card4, @card3, @card6, @card7])
+
+    @player1 = Player.new("Megan", @deck1)
+    @player2 = Player.new("Aurora", @deck2)
+
+    @turn = Turn.new(@player1, @player2)
+
+    assert_equal :mutually_assured_destruction, @turn.type
+  end
 
   def test_it_can_identify_a_turn_winner_when_basic
     assert_equal @player1, @turn.winner


### PR DESCRIPTION
Added tests and updated methods for :mutually_assured_destruction Turn.type AND refactored setup method to address all three turn types so that additional setup isn't required within the tests for not :basic turn types